### PR TITLE
Rename Tree -> Context

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -1,12 +1,12 @@
 import { type } from 'funcadelic';
 
-export const Record = type(class {
+export const Context = type(class {
   static get name() {
-    return 'Record';
+    return 'Context';
   }
 
   childAt(key, parent) {
-    if (parent[Record.symbol]) {
+    if (parent[Context.symbol]) {
       return this(parent).childAt(key, parent);
     } else {
       return parent[key];
@@ -14,4 +14,4 @@ export const Record = type(class {
   }
 });
 
-export const { childAt } = Record.prototype;
+export const { childAt } = Context.prototype;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { compose, view, over, set, Lens, transparent, At, Path } from "./lens";
-export { childAt, Record } from "./record";
+export { childAt, Context } from "./context";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { compose, view, over, set, Lens, transparent, At, Path } from "./lens";
-export { childAt, Tree } from "./tree";
+export { childAt, Record } from "./record";

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,6 +1,6 @@
 import { Functor, map, Semigroup } from 'funcadelic';
 
-import { childAt } from './record';
+import { childAt } from './context';
 
 class Box {
   static get of() {

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,6 +1,6 @@
 import { Functor, map, Semigroup } from 'funcadelic';
 
-import { childAt } from './tree';
+import { childAt } from './record';
 
 class Box {
   static get of() {

--- a/src/record.js
+++ b/src/record.js
@@ -1,12 +1,12 @@
 import { type } from 'funcadelic';
 
-export const Tree = type(class {
+export const Record = type(class {
   static get name() {
-    return 'Tree';
+    return 'Record';
   }
 
   childAt(key, parent) {
-    if (parent[Tree.symbol]) {
+    if (parent[Record.symbol]) {
       return this(parent).childAt(key, parent);
     } else {
       return parent[key];
@@ -14,4 +14,4 @@ export const Tree = type(class {
   }
 });
 
-export const { childAt } = Tree.prototype;
+export const { childAt } = Record.prototype;


### PR DESCRIPTION
The lens abstraction is over getting and setting named (or indexed) properties. With `defineChildren` gone, it feels like `Record` is a more appropriate name for this abstraction.