### PR TITLE
Rename childAt() to just at()

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -5,13 +5,13 @@ export const Context = type(class {
     return 'Context';
   }
 
-  childAt(key, parent) {
+  at(key, parent) {
     if (parent[Context.symbol]) {
-      return this(parent).childAt(key, parent);
+      return this(parent).at(key, parent);
     } else {
       return parent[key];
     }
   }
 });
 
-export const { childAt } = Context.prototype;
+export const { at } = Context.prototype;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { compose, view, over, set, Lens, transparent, At, Path } from "./lens";
-export { childAt, Context } from "./context";
+export { at, Context } from "./context";

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,6 +1,5 @@
 import { Functor, map, Semigroup } from 'funcadelic';
-
-import { childAt } from './context';
+import { at } from './context';
 
 class Box {
   static get of() {
@@ -61,7 +60,7 @@ export function Lens(get, set) {
 export const transparent = Lens(x => x, y => y);
 
 export function At(property, container) {
-  let get = context => context != null ? childAt(property, context) : undefined;
+  let get = context => context != null ? at(property, context) : undefined;
   let set = (part, whole) => {
     let context = whole == null ? (Array.isArray(container) ? [] : {}) : whole;
     if (part === context[property]) {


### PR DESCRIPTION
This feels simpler, and also in keeping with the nomenclature of the `At()` lens.

> Note: I'm not really sure what is the best name for this function which is why I saved it for last.