### PR TITLE
Ensure integer paths produce arrays

### DIFF
--- a/src/lens.js
+++ b/src/lens.js
@@ -59,10 +59,12 @@ export function Lens(get, set) {
 
 export const transparent = Lens(x => x, y => y);
 
+const isInteger =  n => (n << 0) === n;
+
 export function At(property, container) {
   let get = context => context != null ? at(property, context) : undefined;
   let set = (part, whole) => {
-    let context = whole == null ? (Array.isArray(container) ? [] : {}) : whole;
+    let context = whole == null ? (Array.isArray(container) ? [] : isInteger(property) ? [] : {}) : whole;
     if (part === context[property]) {
       return context;
     } else if (Array.isArray(context)) {
@@ -70,7 +72,7 @@ export function At(property, container) {
       clone[Number(property)] = part;
       return clone;
     } else {
-      return Semigroup.for(Object).append(context, {[property]: part});
+      return Semigroup.for(context.constructor).append(context, {[property]: part});
     }
   };
 

--- a/src/lens.js
+++ b/src/lens.js
@@ -64,7 +64,7 @@ const isInteger =  n => (n << 0) === n;
 export function At(property, container) {
   let get = context => context != null ? at(property, context) : undefined;
   let set = (part, whole) => {
-    let context = whole == null ? (Array.isArray(container) ? [] : isInteger(property) ? [] : {}) : whole;
+    let context = whole == null ? (Array.isArray(container) || isInteger(property)) ? [] : {} : whole;
     if (part === context[property]) {
       return context;
     } else if (Array.isArray(context)) {

--- a/tests/lens.test.js
+++ b/tests/lens.test.js
@@ -27,6 +27,20 @@ describe("At", function() {
   });
 });
 
+describe('creating arrays', () => {
+  describe('when focusing on location 2', () => {
+    let lens;
+    let value;
+    beforeEach(() => {
+      lens = At(2);
+      value = set(lens, 'hi', undefined);
+    });
+    it('creates an array with value at 2nd position', () => {
+      expect(value).toEqual([undefined,undefined,'hi']);
+    });
+  });
+});
+
 describe("Path", () => {
   let userNameLens;
   let result;

--- a/tests/lens.test.js
+++ b/tests/lens.test.js
@@ -1,25 +1,141 @@
 /* global describe, it, beforeEach */
-import expect from 'expect';
-import { compose, view, set, At } from '../src/lens';
+import expect from "expect";
+import { compose, view, set, At, Path, over } from "../src/lens";
 
-describe('At', function() {
+describe("At", function() {
   let lens;
   beforeEach(function() {
-    lens = compose(At(0, []), At("hello"));
+    lens = compose(
+      At(0, []),
+      At("hello")
+    );
   });
 
-  it('instantiates objects of the correct type at each path', function() {
-    expect(set(lens, "world", undefined)).toEqual([{hello: 'world'}]);
+  it("instantiates objects of the correct type at each path", function() {
+    expect(set(lens, "world", undefined)).toEqual([{ hello: "world" }]);
   });
 
-  it('set-get: view retrievs what set put in', function() {
+  it("set-get: view retrievs what set put in", function() {
     let cookie = {};
     let object = set(lens, cookie, undefined);
     expect(view(lens, object)).toBe(cookie);
   });
 
-  it('get-set: If you set focus to the same value it has, the whole does not change', function() {
+  it("get-set: If you set focus to the same value it has, the whole does not change", function() {
     let object = set(lens, "world", undefined);
     expect(set(lens, "world", object)).toBe(object);
+  });
+});
+
+describe("Path", () => {
+  let userNameLens;
+  let result;
+  beforeEach(() => {
+    userNameLens = Path(["user", "name"]);
+  });
+  describe("set", () => {
+    describe("when value is an object", () => {
+      let value = { user: { name: "Bob" } };
+      beforeEach(() => {
+        result = set(userNameLens, "Bobby", value);
+      });
+      it("creates a new context at root", () => {
+        expect(result).not.toBe(value);
+      });
+      it("creates a new context in middle location", () => {
+        expect(result.user).not.toBe(value.user);
+      });
+      it("applies the value at focus", () => {
+        expect(result).toHaveProperty(["user", "name"], "Bobby");
+      });
+    });
+    describe("when value is undefined", () => {
+      beforeEach(() => {
+        result = set(userNameLens, "John", undefined);
+      });
+      it("creates context", () => {
+        expect(result).toMatchObject({
+          user: {
+            name: "John"
+          }
+        });
+      });
+    });
+  });
+  describe("view", () => {
+    describe("when value is present", () => {
+      beforeEach(() => {
+        result = view(userNameLens, { user: { name: "Frank" } });
+      });
+      it("returns the value at focus", () => {
+        expect(result).toBe("Frank");
+      });
+    });
+    describe("when value is not present", () => {
+      beforeEach(() => {
+        result = view(userNameLens, undefined);
+      });
+      it("returns undefined", () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+  describe("over", () => {
+    describe("when value is present", () => {
+      let value = { user: { name: "George" } };
+      beforeEach(() => {
+        result = over(userNameLens, s => s.toUpperCase(), value);
+      });
+      it("applies the function to the focus", () => {
+        expect(result).toHaveProperty(["user", "name"], "GEORGE");
+      });
+    });
+    describe("when value is not present", () => {
+      let value = undefined;
+      beforeEach(() => {
+        result = over(userNameLens, (s = "") => s.toUpperCase(), value);
+      });
+      it("creates context for the value", () => {
+        expect(result).toMatchObject({
+          user: {
+            name: ""
+          }
+        });
+      });
+    });
+  });
+  describe("composition with At", () => {
+    let lens;
+    beforeEach(() => {
+      lens = compose(
+        At(0),
+        userNameLens
+      );
+    });
+    describe("set", () => {
+      beforeEach(() => {
+        result = set(lens, "Will");
+      });
+      it("creates composed context", () => {
+        expect(result).toMatchObject([{ user: { name: "Will" } }]);
+      });
+    });
+    describe("view", () => {
+      beforeEach(() => {
+        result = view(lens, [{ user: { name: "Rob" } }]);
+      });
+      it("returns value from focus", () => {
+        expect(result).toBe("Rob");
+      });
+    });
+    describe("over", () => {
+      let value = [{ user: { name: "john" } }];
+      beforeEach(() => {
+        result = over(lens, s => s.toUpperCase(), value);
+      });
+      it("creates the context", () => {
+        expect(result).toMatchObject([{ user: { name: "JOHN" } }]);
+      });
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Ramda lenses allow you to create arrays by passing integers to `lensPath` lens constructor. This is a helpful way to construct context when providing a path. I also noticed that when transitioning an ArrayType Microstate, the result of the transition has an object in the value instead of an array. I believe this stems from the same problem.

# Approach

When creating context for a value, I detect if path is an integer and create an array context instead of an object. 